### PR TITLE
Add cmocka tests, test shim, Makefile targets and CI test jobs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,12 +6,121 @@ on:
     tags: ['v*']
   pull_request:
     branches: [main]
+  workflow_dispatch:
+    inputs:
+      run_privileged:
+        description: "Run privileged tests (requires CAP_NET_RAW on Linux)"
+        type: boolean
+        default: false
+      run_coverage:
+        description: "Run coverage build (gcov) on Linux"
+        type: boolean
+        default: false
 
 concurrency:
   group: build-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:
+  test:
+    name: test-${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: true
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install Linux test dependencies
+        if: runner.os == 'Linux'
+        run: |
+          set -euo pipefail
+          sudo apt-get update
+          sudo apt-get install -y libcmocka-dev pkg-config
+
+      - name: Install macOS test dependencies
+        if: runner.os == 'macOS'
+        run: |
+          set -euo pipefail
+          brew update
+          brew install cmocka pkg-config
+
+      - name: Run unit + integration tests
+        run: |
+          set -euo pipefail
+          make test
+
+  sanitizer:
+    name: sanitizer-linux
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install Linux test dependencies
+        run: |
+          set -euo pipefail
+          sudo apt-get update
+          sudo apt-get install -y libcmocka-dev pkg-config
+
+      - name: Run tests with ASan/UBSan
+        run: |
+          set -euo pipefail
+          make test SANITIZE=1
+
+  privileged:
+    name: privileged-tests-linux
+    if: github.event_name == 'workflow_dispatch' && inputs.run_privileged == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install Linux test dependencies
+        run: |
+          set -euo pipefail
+          sudo apt-get update
+          sudo apt-get install -y libcmocka-dev pkg-config
+
+      - name: Run privileged tests
+        run: |
+          set -euo pipefail
+          make test-privileged
+
+  coverage:
+    name: coverage-linux
+    if: github.event_name == 'workflow_dispatch' && inputs.run_coverage == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install Linux test dependencies
+        run: |
+          set -euo pipefail
+          sudo apt-get update
+          sudo apt-get install -y libcmocka-dev pkg-config
+
+      - name: Run coverage build
+        run: |
+          set -euo pipefail
+          make coverage
+          gcov -o . lltdDaemon/lltdTlvOps.c
+
+      - name: Collect coverage artifacts
+        run: |
+          set -euo pipefail
+          mkdir -p coverage-artifacts
+          find . -name '*.gcov' -o -name '*.gcda' -o -name '*.gcno' | xargs -I{} cp --parents {} coverage-artifacts
+
+      - name: Upload coverage artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: lltd-coverage
+          path: coverage-artifacts
+
   build:
     name: ${{ matrix.os }}-${{ matrix.compiler }}-${{ matrix.build_type }}
     runs-on: ${{ matrix.os }}

--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,20 @@
 CC     := gcc
 CFLAGS += -Wall -Wextra
 
+TEST_DIR := build/tests
+TEST_CFLAGS := $(CFLAGS) -IlltdDaemon -DLLTD_TESTING
+TEST_LDFLAGS :=
+
+ifneq ($(SANITIZE),)
+	TEST_CFLAGS += -fsanitize=address,undefined -fno-omit-frame-pointer -g
+	TEST_LDFLAGS += -fsanitize=address,undefined
+endif
+
+ifneq ($(COVERAGE),)
+	TEST_CFLAGS += --coverage -O0 -g
+	TEST_LDFLAGS += --coverage
+endif
+
 UNAME_S := $(shell uname -s)
 ifeq ($(UNAME_S),Linux)
 	CCFLAGS += -D LINUX
@@ -56,11 +70,44 @@ all: lltdResponder
 lltdResponder: $(LLTD_SRC_FILES)
 	gcc -o lltdReponder $(LLTD_SRC_FILES)
 
+test-check:
+	@pkg-config --exists cmocka || (echo "cmocka not found (pkg-config cmocka). Install cmocka to run tests." >&2; exit 1)
+
+$(TEST_DIR):
+	mkdir -p $(TEST_DIR)
+
+test-unit: test-check $(TEST_DIR)
+	$(CC) $(TEST_CFLAGS) $$(pkg-config --cflags cmocka) \
+		lltdDaemon/lltdTlvOps.c tests/test_shims.c tests/test_lltd_tlv_ops.c \
+		$(TEST_LDFLAGS) $$(pkg-config --libs cmocka) -o $(TEST_DIR)/unit_tests
+	$(TEST_DIR)/unit_tests
+
+test-integration: test-check $(TEST_DIR)
+	$(CC) $(TEST_CFLAGS) $$(pkg-config --cflags cmocka) \
+		lltdDaemon/lltdTlvOps.c tests/test_shims.c tests/test_lltd_integration.c \
+		$(TEST_LDFLAGS) $$(pkg-config --libs cmocka) -o $(TEST_DIR)/integration_tests
+	$(TEST_DIR)/integration_tests
+
+test-privileged: test-check $(TEST_DIR)
+	$(CC) $(TEST_CFLAGS) $$(pkg-config --cflags cmocka) \
+		tests/test_shims.c tests/test_lltd_privileged.c \
+		$(TEST_LDFLAGS) $$(pkg-config --libs cmocka) -o $(TEST_DIR)/privileged_tests
+	$(TEST_DIR)/privileged_tests
+
+test: test-unit test-integration
+
+coverage: COVERAGE=1
+coverage: test
+
+clean-tests:
+	-rm -rf $(TEST_DIR)
+	-rm -f *.gcda *.gcno *.gcov lltdDaemon/*.gcda lltdDaemon/*.gcno lltdDaemon/*.gcov tests/*.gcda tests/*.gcno tests/*.gcov
 
 clean:
 	-rm -f lltdResponder
+	-rm -rf $(TEST_DIR)
 
 %: %.c
 	$(CC) $(CFLAGS) -o $@ $<
 
-.PHONY: all linux clean
+.PHONY: all linux clean test test-unit test-integration test-privileged test-check coverage clean-tests

--- a/lltdDaemon/lltdTestShim.h
+++ b/lltdDaemon/lltdTestShim.h
@@ -1,0 +1,47 @@
+#ifndef LLTD_TEST_SHIM_H
+#define LLTD_TEST_SHIM_H
+
+#include <arpa/inet.h>
+#include <ifaddrs.h>
+#include <net/if.h>
+#include <netinet/in.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/socket.h>
+
+#include "lltdBlock.h"
+
+#ifndef KERN_SUCCESS
+#define KERN_SUCCESS 0
+#endif
+
+#ifndef IFM_FDX
+#define IFM_FDX 0x0010
+#endif
+
+typedef bool boolean_t;
+
+typedef struct {
+    const char *deviceName;
+    uint32_t    ifType;
+    uint32_t    MediumType;
+    uint32_t    flags;
+    uint32_t    LinkSpeed;
+    uint8_t     macAddress[6];
+} network_interface_t;
+
+#define lltdEtherType 0x88D9
+
+void getMachineName(char **name, size_t *size);
+void getSupportInfo(void **info, size_t *size);
+void getUpnpUuid(void **uuid);
+uint8_t getWifiMode(void *networkInterface);
+bool getBSSID(void *bssid, void *networkInterface);
+bool getSSID(char **ssid, size_t *size, void *networkInterface);
+bool getWifiMaxRate(uint32_t *rate, void *networkInterface);
+bool getWifiRssi(int8_t *rssi, void *networkInterface);
+bool getWifiPhyMedium(uint32_t *medium, void *networkInterface);
+
+#endif

--- a/lltdDaemon/lltdTlvOps.c
+++ b/lltdDaemon/lltdTlvOps.c
@@ -8,7 +8,11 @@
  *                                                                            *
  ******************************************************************************/
 
-#include    "lltdDaemon.h"
+#ifdef LLTD_TESTING
+#include "lltdTestShim.h"
+#else
+#include "lltdDaemon.h"
+#endif
 
 #pragma mark -
 #pragma mark Header generation

--- a/tests/test_lltd_integration.c
+++ b/tests/test_lltd_integration.c
@@ -1,0 +1,85 @@
+#include <ifaddrs.h>
+#include <stddef.h>
+#include <stdint.h>
+#include <string.h>
+
+#include <cmocka.h>
+
+#include "lltdTestShim.h"
+#include "lltdTlvOps.h"
+
+static char *find_ipv4_interface(void) {
+    struct ifaddrs *interfaces = NULL;
+    if (getifaddrs(&interfaces) != 0) {
+        return NULL;
+    }
+
+    char *name = NULL;
+    for (struct ifaddrs *cursor = interfaces; cursor != NULL; cursor = cursor->ifa_next) {
+        if (!cursor->ifa_addr) {
+            continue;
+        }
+        if (cursor->ifa_addr->sa_family == AF_INET) {
+            name = strdup(cursor->ifa_name);
+            break;
+        }
+    }
+
+    freeifaddrs(interfaces);
+    return name;
+}
+
+static void test_set_ipv4_tlv_uses_interface(void **state) {
+    (void)state;
+    char *iface_name = find_ipv4_interface();
+    if (!iface_name) {
+        print_message("No IPv4 interface found; skipping integration test.\n");
+        return;
+    }
+
+    network_interface_t iface = {
+        .deviceName = iface_name,
+    };
+    uint8_t buffer[sizeof(generic_tlv_t) + sizeof(uint32_t)] = {0};
+
+    size_t written = setIPv4TLV(buffer, 0, &iface);
+
+    assert_int_equal(written, sizeof(generic_tlv_t) + sizeof(uint32_t));
+    generic_tlv_t *hdr = (generic_tlv_t *)buffer;
+    assert_int_equal(hdr->TLVType, tlv_ipv4);
+    assert_int_equal(hdr->TLVLength, sizeof(uint32_t));
+
+    free(iface_name);
+}
+
+static void test_set_ipv6_tlv_uses_interface(void **state) {
+    (void)state;
+    char *iface_name = find_ipv4_interface();
+    if (!iface_name) {
+        print_message("No IPv4 interface found; skipping IPv6 integration test.\n");
+        return;
+    }
+
+    network_interface_t iface = {
+        .deviceName = iface_name,
+    };
+    uint8_t buffer[sizeof(generic_tlv_t) + sizeof(struct in6_addr)] = {0};
+
+    size_t written = setIPv6TLV(buffer, 0, &iface);
+
+    assert_int_equal(written, sizeof(generic_tlv_t) + sizeof(struct in6_addr));
+    generic_tlv_t *hdr = (generic_tlv_t *)buffer;
+    assert_int_equal(hdr->TLVType, tlv_ipv6);
+    assert_int_equal(hdr->TLVLength, sizeof(struct in6_addr));
+
+    free(iface_name);
+}
+
+int main(void) {
+    const struct CMUnitTest tests[] = {
+        cmocka_unit_test(test_set_ipv4_tlv_uses_interface),
+        cmocka_unit_test(test_set_ipv6_tlv_uses_interface),
+    };
+
+    return cmocka_run_group_tests(tests, NULL, NULL);
+}

--- a/tests/test_lltd_privileged.c
+++ b/tests/test_lltd_privileged.c
@@ -1,0 +1,38 @@
+#include <errno.h>
+#include <stddef.h>
+
+#include <cmocka.h>
+
+#include "lltdTestShim.h"
+
+#ifdef __linux__
+#include <sys/socket.h>
+#include <unistd.h>
+#endif
+
+static void test_raw_socket_open(void **state) {
+    (void)state;
+#ifdef __linux__
+    int fd = socket(AF_PACKET, SOCK_RAW, htons(lltdEtherType));
+    if (fd < 0) {
+        if (errno == EPERM || errno == EACCES) {
+            print_message("Raw socket unavailable without CAP_NET_RAW; skipping.\n");
+            return;
+        }
+    }
+    assert_true(fd >= 0);
+    if (fd >= 0) {
+        close(fd);
+    }
+#else
+    print_message("Raw socket test is Linux-only; skipping.\n");
+#endif
+}
+
+int main(void) {
+    const struct CMUnitTest tests[] = {
+        cmocka_unit_test(test_raw_socket_open),
+    };
+
+    return cmocka_run_group_tests(tests, NULL, NULL);
+}

--- a/tests/test_lltd_tlv_ops.c
+++ b/tests/test_lltd_tlv_ops.c
@@ -1,0 +1,83 @@
+#include <arpa/inet.h>
+#include <stddef.h>
+#include <stdint.h>
+
+#include <cmocka.h>
+
+#include "lltdTestShim.h"
+#include "lltdTlvOps.h"
+
+static void test_compare_ethernet_address_equal(void **state) {
+    (void)state;
+    ethernet_address_t a = {{0x00, 0x11, 0x22, 0x33, 0x44, 0x55}};
+    ethernet_address_t b = {{0x00, 0x11, 0x22, 0x33, 0x44, 0x55}};
+
+    assert_true(compareEthernetAddress(&a, &b));
+}
+
+static void test_compare_ethernet_address_not_equal(void **state) {
+    (void)state;
+    ethernet_address_t a = {{0x00, 0x11, 0x22, 0x33, 0x44, 0x55}};
+    ethernet_address_t b = {{0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff}};
+
+    assert_false(compareEthernetAddress(&a, &b));
+}
+
+static void test_set_lltd_header_populates_fields(void **state) {
+    (void)state;
+    uint8_t buffer[sizeof(lltd_demultiplex_header_t)] = {0};
+    ethernet_address_t source = {{0x00, 0x11, 0x22, 0x33, 0x44, 0x55}};
+    ethernet_address_t destination = {{0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff}};
+
+    size_t written = setLltdHeader(buffer, &source, &destination, 0x1234, opcode_probe, tos_discovery);
+
+    assert_int_equal(written, sizeof(lltd_demultiplex_header_t));
+    lltd_demultiplex_header_t *header = (lltd_demultiplex_header_t *)buffer;
+    assert_int_equal(header->frameHeader.ethertype, htons(lltdEtherType));
+    assert_memory_equal(&header->frameHeader.source, &source, sizeof(source));
+    assert_memory_equal(&header->frameHeader.destination, &destination, sizeof(destination));
+    assert_memory_equal(&header->realSource, &source, sizeof(source));
+    assert_memory_equal(&header->realDestination, &destination, sizeof(destination));
+    assert_int_equal(header->seqNumber, 0x1234);
+    assert_int_equal(header->opcode, opcode_probe);
+    assert_int_equal(header->tos, tos_discovery);
+    assert_int_equal(header->version, 1);
+}
+
+static void test_set_hello_header_writes_payload(void **state) {
+    (void)state;
+    uint8_t buffer[sizeof(lltd_demultiplex_header_t) + sizeof(lltd_hello_upper_header_t)] = {0};
+    ethernet_address_t apparent = {{0x01, 0x02, 0x03, 0x04, 0x05, 0x06}};
+    ethernet_address_t current = {{0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f}};
+
+    size_t written = setHelloHeader(buffer, sizeof(lltd_demultiplex_header_t), &apparent, &current, 0x42);
+
+    assert_int_equal(written, sizeof(lltd_hello_upper_header_t));
+    lltd_hello_upper_header_t *hello =
+        (lltd_hello_upper_header_t *)(buffer + sizeof(lltd_demultiplex_header_t));
+    assert_memory_equal(&hello->apparentMapper, &apparent, sizeof(apparent));
+    assert_memory_equal(&hello->currentMapper, &current, sizeof(current));
+    assert_int_equal(hello->generation, 0x42);
+}
+
+static void test_set_end_of_property_tlv_marks_buffer(void **state) {
+    (void)state;
+    uint8_t buffer[4] = {0};
+
+    size_t written = setEndOfPropertyTLV(buffer, 2);
+
+    assert_int_equal(written, sizeof(uint8_t));
+    assert_int_equal(buffer[2], eofpropmarker);
+}
+
+int main(void) {
+    const struct CMUnitTest tests[] = {
+        cmocka_unit_test(test_compare_ethernet_address_equal),
+        cmocka_unit_test(test_compare_ethernet_address_not_equal),
+        cmocka_unit_test(test_set_lltd_header_populates_fields),
+        cmocka_unit_test(test_set_hello_header_writes_payload),
+        cmocka_unit_test(test_set_end_of_property_tlv_marks_buffer),
+    };
+
+    return cmocka_run_group_tests(tests, NULL, NULL);
+}

--- a/tests/test_shims.c
+++ b/tests/test_shims.c
@@ -1,0 +1,81 @@
+#include "lltdTestShim.h"
+
+#include <stdlib.h>
+
+void getMachineName(char **name, size_t *size) {
+    const char *value = "lltd-test-host";
+    size_t len = strlen(value);
+    char *copy = malloc(len + 1);
+    if (!copy) {
+        *name = NULL;
+        *size = 0;
+        return;
+    }
+    memcpy(copy, value, len + 1);
+    *name = copy;
+    *size = len;
+}
+
+void getSupportInfo(void **info, size_t *size) {
+    const char *value = "https://example.invalid/support";
+    size_t len = strlen(value);
+    char *copy = malloc(len + 1);
+    if (!copy) {
+        *info = NULL;
+        *size = 0;
+        return;
+    }
+    memcpy(copy, value, len + 1);
+    *info = copy;
+    *size = len;
+}
+
+void getUpnpUuid(void **uuid) {
+    uint8_t *buffer = calloc(1, 16);
+    *uuid = buffer;
+}
+
+uint8_t getWifiMode(void *networkInterface) {
+    (void)networkInterface;
+    return 0;
+}
+
+bool getBSSID(void *bssid, void *networkInterface) {
+    (void)networkInterface;
+    if (!bssid) {
+        return false;
+    }
+    memset(bssid, 0, 6);
+    return true;
+}
+
+bool getSSID(char **ssid, size_t *size, void *networkInterface) {
+    (void)networkInterface;
+    *ssid = NULL;
+    *size = 0;
+    return false;
+}
+
+bool getWifiMaxRate(uint32_t *rate, void *networkInterface) {
+    (void)networkInterface;
+    if (rate) {
+        *rate = 0;
+    }
+    return false;
+}
+
+bool getWifiRssi(int8_t *rssi, void *networkInterface) {
+    (void)networkInterface;
+    if (rssi) {
+        *rssi = 0;
+    }
+    return false;
+}
+
+bool getWifiPhyMedium(uint32_t *medium, void *networkInterface) {
+    (void)networkInterface;
+    if (medium) {
+        *medium = 0;
+    }
+    return false;
+}


### PR DESCRIPTION
### Motivation
- Introduce an automated test flow for the LLTD daemon to validate TLV/frame encoding/decoding and networking-related helpers without relying on manual runs or platform-specific I/O.
- Separate test classes into unit (no network), integration (non-privileged network info), and optional privileged tests (raw sockets) so CI/maintainers can run the appropriate level safely. 
- Add sanitizer and optional coverage runs to catch memory/undefined behavior regressions early in CI. 

### Description
- Add cmocka-based tests and shims: new `lltdDaemon/lltdTestShim.h` and test sources under `tests/` (`test_lltd_tlv_ops.c`, `test_lltd_integration.c`, `test_lltd_privileged.c`, `test_shims.c`).
- Make `lltdTlvOps.c` include the shim under `LLTD_TESTING` to decouple platform I/O and allow in-process tests (`#ifdef LLTD_TESTING` switch).
- Extend `Makefile` with test-related targets and flags: `test`, `test-unit`, `test-integration`, `test-privileged`, `test SANITIZE=1`, `coverage` and helper `test-check`, plus `SANITIZE` and `COVERAGE` build flags for ASan/UBSan and gcov respectively.
- Update CI: `.github/workflows/build.yml` now runs a `test` job on `ubuntu-latest` and `macos-latest`, a Linux `sanitizer` job, and provides opt-in `privileged` and `coverage` jobs via `workflow_dispatch` inputs (`run_privileged`, `run_coverage`).

### Testing
- No automated tests were executed locally in this environment because `cmocka` is not installed here, so test binaries were not run. 
- The workflow is configured to run unit + integration tests automatically on pushes/PRs and to run sanitizer tests on Linux. 
- Privileged tests and coverage are configured as opt-in and will run only when triggered via `workflow_dispatch` with `run_privileged=true` or `run_coverage=true`. 
- To run tests locally after installing dependencies, use `make test`, `make test-unit`, `make test-integration`, `make test-privileged`, `make test SANITIZE=1`, or `make coverage`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6954b3f120d8832eb025ea0602c8503d)