### PR TITLE
Fix CI build errors for macOS universal build

### DIFF
--- a/lltdDaemon.xcodeproj/project.pbxproj
+++ b/lltdDaemon.xcodeproj/project.pbxproj
@@ -7,9 +7,8 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		C1A0D7D618E01E0900863EA1 /* lltd_wifi_corewlan.m in Sources */ = {isa = PBXBuildFile; fileRef = C1A0D7D518E01E0900863EA1 /* lltd_wifi_corewlan.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
+		C1A0D7D618E01E0900863EA1 /* lltd_wifi_iokit.c in Sources */ = {isa = PBXBuildFile; fileRef = C1A0D7D518E01E0900863EA1 /* lltd_wifi_iokit.c */; };
 		C1A0D7D618E01E0900863EA2 /* lltd_wifi_rates.c in Sources */ = {isa = PBXBuildFile; fileRef = C1A0D7D518E01E0900863EA2 /* lltd_wifi_rates.c */; };
-		C1A0D7D618E01E0900863EA5 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C1A0D7D518E01E0900863EA5 /* Foundation.framework */; };
 		E500D7D618E01E0900863EAC /* darwin-ops.c in Sources */ = {isa = PBXBuildFile; fileRef = E500D7D518E01E0900863EAC /* darwin-ops.c */; };
 		E500D7DD18E02F3900863EAC /* ImageIO.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E500D7DC18E02F3900863EAC /* ImageIO.framework */; };
 		E500D7E318E0427200863EAC /* CoreServices.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E500D7E218E0427200863EAC /* CoreServices.framework */; };
@@ -56,11 +55,10 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
-		C1A0D7D518E01E0900863EA1 /* lltd_wifi_corewlan.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = "lltd_wifi_corewlan.m"; path = "lltdDaemon/darwin/lltd_wifi_corewlan.m"; sourceTree = SOURCE_ROOT; };
+		C1A0D7D518E01E0900863EA1 /* lltd_wifi_iokit.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = "lltd_wifi_iokit.c"; path = "lltdDaemon/darwin/lltd_wifi_iokit.c"; sourceTree = SOURCE_ROOT; };
 		C1A0D7D518E01E0900863EA2 /* lltd_wifi_rates.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = "lltd_wifi_rates.c"; path = "lltdDaemon/darwin/lltd_wifi_rates.c"; sourceTree = SOURCE_ROOT; };
 		C1A0D7D518E01E0900863EA3 /* lltd_wifi_corewlan.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = "lltd_wifi_corewlan.h"; path = "lltdDaemon/darwin/lltd_wifi_corewlan.h"; sourceTree = SOURCE_ROOT; };
 		C1A0D7D518E01E0900863EA4 /* lltd_wifi_rates.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = "lltd_wifi_rates.h"; path = "lltdDaemon/darwin/lltd_wifi_rates.h"; sourceTree = SOURCE_ROOT; };
-		C1A0D7D518E01E0900863EA5 /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = System/Library/Frameworks/Foundation.framework; sourceTree = SDKROOT; };
 		E500D7D518E01E0900863EAC /* darwin-ops.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = "darwin-ops.c"; path = "lltdDaemon/darwin/darwin-ops.c"; sourceTree = SOURCE_ROOT; };
 		E500D7D718E01E1800863EAC /* darwin-ops.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = "darwin-ops.h"; path = "lltdDaemon/darwin/darwin-ops.h"; sourceTree = SOURCE_ROOT; };
 		E500D7DC18E02F3900863EAC /* ImageIO.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = ImageIO.framework; path = System/Library/Frameworks/ImageIO.framework; sourceTree = SDKROOT; };
@@ -93,7 +91,6 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				C1A0D7D618E01E0900863EA5 /* Foundation.framework in Frameworks */,
 				E59ADBBE1C80982300895932 /* SystemConfiguration.framework in Frameworks */,
 				E500D7E318E0427200863EAC /* CoreServices.framework in Frameworks */,
 				E500D7DD18E02F3900863EAC /* ImageIO.framework in Frameworks */,
@@ -139,7 +136,6 @@
 		E52240FA18CF0CA200DD9E2F /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
-				C1A0D7D518E01E0900863EA5 /* Foundation.framework */,
 				E59ADBBD1C80982300895932 /* SystemConfiguration.framework */,
 				E500D7E218E0427200863EAC /* CoreServices.framework */,
 				E500D7DC18E02F3900863EAC /* ImageIO.framework */,
@@ -160,7 +156,7 @@
 				E5774FA718D61F5E00988358 /* darwin-main.h */,
 				E500D7D518E01E0900863EAC /* darwin-ops.c */,
 				E500D7D718E01E1800863EAC /* darwin-ops.h */,
-				C1A0D7D518E01E0900863EA1 /* lltd_wifi_corewlan.m */,
+				C1A0D7D518E01E0900863EA1 /* lltd_wifi_iokit.c */,
 				C1A0D7D518E01E0900863EA3 /* lltd_wifi_corewlan.h */,
 				C1A0D7D518E01E0900863EA2 /* lltd_wifi_rates.c */,
 				C1A0D7D518E01E0900863EA4 /* lltd_wifi_rates.h */,
@@ -246,7 +242,7 @@
 			files = (
 				E5A41A0E19082C0B00D5D2FD /* darwin-main.c in Sources */,
 				E500D7D618E01E0900863EAC /* darwin-ops.c in Sources */,
-				C1A0D7D618E01E0900863EA1 /* lltd_wifi_corewlan.m in Sources */,
+				C1A0D7D618E01E0900863EA1 /* lltd_wifi_iokit.c in Sources */,
 				C1A0D7D618E01E0900863EA2 /* lltd_wifi_rates.c in Sources */,
 				FAD3A21C19EACF54000FB445 /* lltdAutomata.c in Sources */,
 				E53E69BF1908293B0033F651 /* lltdBlock.c in Sources */,

--- a/lltdDaemon.xcodeproj/project.pbxproj
+++ b/lltdDaemon.xcodeproj/project.pbxproj
@@ -7,7 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		C1A0D7D618E01E0900863EA1 /* lltd_wifi_corewlan.m in Sources */ = {isa = PBXBuildFile; fileRef = C1A0D7D518E01E0900863EA1 /* lltd_wifi_corewlan.m */; };
+		C1A0D7D618E01E0900863EA1 /* lltd_wifi_corewlan.m in Sources */ = {isa = PBXBuildFile; fileRef = C1A0D7D518E01E0900863EA1 /* lltd_wifi_corewlan.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
 		C1A0D7D618E01E0900863EA2 /* lltd_wifi_rates.c in Sources */ = {isa = PBXBuildFile; fileRef = C1A0D7D518E01E0900863EA2 /* lltd_wifi_rates.c */; };
 		C1A0D7D618E01E0900863EA5 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C1A0D7D518E01E0900863EA5 /* Foundation.framework */; };
 		E500D7D618E01E0900863EAC /* darwin-ops.c in Sources */ = {isa = PBXBuildFile; fileRef = E500D7D518E01E0900863EAC /* darwin-ops.c */; };

--- a/lltdDaemon/darwin/lltd_wifi_iokit.c
+++ b/lltdDaemon/darwin/lltd_wifi_iokit.c
@@ -1,0 +1,241 @@
+/******************************************************************************
+ *                                                                            *
+ *   lltd_wifi_iokit.c                                                        *
+ *   lltdDaemon                                                               *
+ *                                                                            *
+ *   Pure C implementation of Wi-Fi metrics using IOKit.                      *
+ *   No Objective-C, no ARC, no libarclite dependency.                        *
+ *                                                                            *
+ *   Created by Răzvan Corneliu C.R. VILT on 07.01.2026.                      *
+ *   Copyright © 2014-2026 Răzvan Corneliu C.R. VILT. All rights reserved.    *
+ *                                                                            *
+ ******************************************************************************/
+
+#include "lltd_wifi_corewlan.h"
+#include "lltd_wifi_rates.h"
+
+#ifdef __APPLE__
+
+#include <CoreFoundation/CoreFoundation.h>
+#include <IOKit/IOKitLib.h>
+#include <string.h>
+#include <stdlib.h>
+
+/* IOKit property keys for Wi-Fi (IO80211) */
+#define kIO80211RSSI            "IO80211RSSI"
+#define kIO80211Noise           "IO80211Noise"
+#define kIO80211LinkSpeed       "IO80211LinkSpeed"
+#define kIO80211TxRate          "IO80211TxRate"
+#define kIO80211PHYMode         "IO80211PHYMode"
+#define kIO80211ChannelWidth    "IO80211ChannelWidth"
+#define kIO80211Channel         "IO80211Channel"
+#define kIO80211BSSID           "IO80211BSSID"
+
+/*
+ * Search for a property in the IOKit registry.
+ * Searches both children (legacy) and parents (Skywalk on Tahoe+).
+ */
+static CFTypeRef copyWiFiPropertyByName(const char *interfaceName, CFStringRef key) {
+    if (!interfaceName || !key) {
+        return NULL;
+    }
+
+    /* Get the interface service by BSD name */
+    io_service_t interfaceService = IOServiceGetMatchingService(
+        kIOMainPortDefault,
+        IOBSDNameMatching(kIOMainPortDefault, 0, interfaceName)
+    );
+    if (!interfaceService) {
+        return NULL;
+    }
+
+    /* First try searching children (legacy IOKit stack) */
+    CFTypeRef value = IORegistryEntrySearchCFProperty(
+        interfaceService,
+        kIOServicePlane,
+        key,
+        kCFAllocatorDefault,
+        kIORegistryIterateRecursively
+    );
+
+    /* If not found, search parents (Skywalk stack on Tahoe+) */
+    if (!value) {
+        value = IORegistryEntrySearchCFProperty(
+            interfaceService,
+            kIOServicePlane,
+            key,
+            kCFAllocatorDefault,
+            kIORegistryIterateRecursively | kIORegistryIterateParents
+        );
+    }
+
+    IOObjectRelease(interfaceService);
+    return value;
+}
+
+/*
+ * Get an integer value from an IOKit property.
+ * Returns 0 and sets *found=false if not found or wrong type.
+ */
+static int getIntProperty(const char *ifname, const char *key, int *found) {
+    int result = 0;
+    *found = 0;
+
+    CFStringRef cfKey = CFStringCreateWithCString(kCFAllocatorDefault, key, kCFStringEncodingUTF8);
+    if (!cfKey) {
+        return 0;
+    }
+
+    CFTypeRef value = copyWiFiPropertyByName(ifname, cfKey);
+    CFRelease(cfKey);
+
+    if (value) {
+        if (CFGetTypeID(value) == CFNumberGetTypeID()) {
+            CFNumberGetValue((CFNumberRef)value, kCFNumberIntType, &result);
+            *found = 1;
+        }
+        CFRelease(value);
+    }
+
+    return result;
+}
+
+/*
+ * Check if interface is associated (has a BSSID)
+ */
+static int isAssociated(const char *ifname) {
+    CFTypeRef bssid = copyWiFiPropertyByName(ifname, CFSTR(kIO80211BSSID));
+    if (bssid) {
+        CFRelease(bssid);
+        return 1;
+    }
+    return 0;
+}
+
+/*
+ * Map IOKit PHY mode value to our constants.
+ * IOKit uses same values as CWPHYMode.
+ */
+static int mapPhyMode(int iokitPhyMode) {
+    switch (iokitPhyMode) {
+        case 1:  return LLTD_WIFI_PHY_11A;
+        case 2:  return LLTD_WIFI_PHY_11B;
+        case 3:  return LLTD_WIFI_PHY_11G;
+        case 4:  return LLTD_WIFI_PHY_11N;
+        case 5:  return LLTD_WIFI_PHY_11AC;
+        case 6:  return LLTD_WIFI_PHY_11AX;
+        default: return LLTD_WIFI_PHY_NONE;
+    }
+}
+
+const char *lltd_wifi_phy_mode_name(int phy_mode) {
+    switch (phy_mode) {
+        case LLTD_WIFI_PHY_NONE:  return "none";
+        case LLTD_WIFI_PHY_11A:   return "802.11a";
+        case LLTD_WIFI_PHY_11B:   return "802.11b";
+        case LLTD_WIFI_PHY_11G:   return "802.11g";
+        case LLTD_WIFI_PHY_11N:   return "802.11n";
+        case LLTD_WIFI_PHY_11AC:  return "802.11ac";
+        case LLTD_WIFI_PHY_11AX:  return "802.11ax";
+        default:                  return "unknown";
+    }
+}
+
+int lltd_darwin_wifi_get_metrics(const char *ifname, lltd_wifi_metrics_t *out) {
+    int found;
+
+    /* Validate arguments */
+    if (!ifname || !out) {
+        return -1;
+    }
+
+    /* Zero-initialize output */
+    memset(out, 0, sizeof(lltd_wifi_metrics_t));
+
+    /* Check if interface exists and is associated */
+    if (!isAssociated(ifname)) {
+        return -3;
+    }
+
+    /* Get RSSI */
+    out->rssi_dbm = getIntProperty(ifname, kIO80211RSSI, &found);
+    if (found) {
+        out->flags |= LLTD_WIFI_FLAG_VALID_RSSI;
+    }
+
+    /* Get Noise */
+    out->noise_dbm = getIntProperty(ifname, kIO80211Noise, &found);
+    if (found) {
+        out->flags |= LLTD_WIFI_FLAG_VALID_NOISE;
+    }
+
+    /* Get PHY mode */
+    int rawPhyMode = getIntProperty(ifname, kIO80211PHYMode, &found);
+    if (found) {
+        out->phy_mode = mapPhyMode(rawPhyMode);
+        if (out->phy_mode != LLTD_WIFI_PHY_NONE) {
+            out->flags |= LLTD_WIFI_FLAG_VALID_PHY;
+        }
+    }
+
+    /* Get channel width */
+    out->chan_width_mhz = getIntProperty(ifname, kIO80211ChannelWidth, &found);
+    if (found && out->chan_width_mhz > 0) {
+        out->flags |= LLTD_WIFI_FLAG_VALID_WIDTH;
+    }
+
+    /* Get link speed - try multiple property names */
+    out->link_mbps = getIntProperty(ifname, kIO80211LinkSpeed, &found);
+    if (!found) {
+        out->link_mbps = getIntProperty(ifname, kIO80211TxRate, &found);
+    }
+    if (found && out->link_mbps > 0) {
+        out->flags |= LLTD_WIFI_FLAG_VALID_LINK;
+    } else {
+        /* Cannot proceed without link rate */
+        return -3;
+    }
+
+    /* Compute max link speed based on PHY mode */
+    int phy_family = lltd_wifi_phy_family_from_cwmode(out->phy_mode);
+    int width = out->chan_width_mhz > 0 ? out->chan_width_mhz : 20;
+
+    if (phy_family == WIFI_PHY_LEGACY_B) {
+        /* 802.11b max is 11 Mbps */
+        out->max_link_mbps = 11;
+        out->flags |= LLTD_WIFI_FLAG_VALID_MAX;
+    } else if (phy_family == WIFI_PHY_LEGACY_AG) {
+        /* 802.11a/g max is 54 Mbps */
+        out->max_link_mbps = 54;
+        out->flags |= LLTD_WIFI_FLAG_VALID_MAX;
+    } else if (phy_family != 0) {
+        /* HT/VHT/HE: try to infer NSS/MCS/GI from observed rate */
+        wifi_rate_params_t inferred;
+        int tolerance = 15; /* Allow 15 Mbps tolerance for rate matching */
+
+        if (lltd_wifi_infer_params(phy_family, width, out->link_mbps, tolerance, &inferred) == 0) {
+            /* Successfully inferred parameters */
+            out->nss_inferred = inferred.nss;
+            out->mcs_inferred = inferred.mcs;
+            out->gi_ns_inferred = inferred.gi_ns;
+            out->flags |= LLTD_WIFI_FLAG_VALID_INFER;
+
+            /* Calculate max rate using inferred NSS */
+            out->max_link_mbps = lltd_wifi_calc_max_rate(phy_family, width, inferred.nss);
+            out->flags |= LLTD_WIFI_FLAG_VALID_MAX;
+        } else {
+            /* Could not infer, assume 1 SS and mark as approximate */
+            out->nss_inferred = 1;
+            out->max_link_mbps = lltd_wifi_calc_max_rate(phy_family, width, 1);
+            out->flags |= LLTD_WIFI_FLAG_VALID_MAX | LLTD_WIFI_FLAG_APPROX_MAX;
+        }
+    } else {
+        /* Unknown PHY, use link rate as max */
+        out->max_link_mbps = out->link_mbps;
+        out->flags |= LLTD_WIFI_FLAG_VALID_MAX | LLTD_WIFI_FLAG_APPROX_MAX;
+    }
+
+    return 0;
+}
+
+#endif /* __APPLE__ */

--- a/lltdDaemon/lltdBlock.c
+++ b/lltdDaemon/lltdBlock.c
@@ -782,7 +782,7 @@ void parseFrame(void *frame, void *networkInterface){
         char eth_src_mac[18];
         format_mac_str(header->realSource.a, mapper_id, sizeof(mapper_id));
         format_mac_str(header->frameHeader.source.a, eth_src_mac, sizeof(eth_src_mac));
-    log_debug("parseFrame(): t=%llu discover mapper_id=%s ethSrc=%s tos=%u xid=%u gen_host=0x%04x",
+    log_debug("parseFrame(): t=%llu %s discover mapper_id=%s ethSrc=%s tos=%u xid=%u gen_host=0x%04x",
               (unsigned long long)lltd_now_ms(),
               currentNetworkInterface->deviceName,
               mapper_id,


### PR DESCRIPTION
- Replace @autoreleasepool with NSAutoreleasePool for deployment target 10.4 compatibility (avoids libarclite requirement)
- Add -fno-objc-arc compiler flag to lltd_wifi_corewlan.m
- Fix format string warning in lltdBlock.c (missing %s for deviceName)