### PR TITLE
Core/OS split: extend lltdPort API (memcpy/memcmp/sleep/send_frame)

### DIFF
--- a/lltdResponder/lltdPort.h
+++ b/lltdResponder/lltdPort.h
@@ -10,6 +10,12 @@ uint64_t lltd_port_monotonic_milliseconds(void);
 void *lltd_port_malloc(size_t size);
 void lltd_port_free(void *ptr);
 void *lltd_port_memset(void *ptr, int value, size_t num);
+void *lltd_port_memcpy(void *destination, const void *source, size_t num);
+int lltd_port_memcmp(const void *lhs, const void *rhs, size_t num);
+
+void lltd_port_sleep_ms(uint32_t milliseconds);
+
+int lltd_port_send_frame(void *iface_ctx, const void *frame, size_t frame_len);
 
 void lltd_port_log_debug(const char *fmt, ...);
 void lltd_port_log_warning(const char *fmt, ...);

--- a/os/darwin/lltd_port.c
+++ b/os/darwin/lltd_port.c
@@ -5,6 +5,29 @@
 #include <stdarg.h>
 #include <stdio.h>
 #include <string.h>
+#include <time.h>
+
+void *lltd_port_memcpy(void *destination, const void *source, size_t num) {
+    return memcpy(destination, source, num);
+}
+
+int lltd_port_memcmp(const void *lhs, const void *rhs, size_t num) {
+    return memcmp(lhs, rhs, num);
+}
+
+void lltd_port_sleep_ms(uint32_t milliseconds) {
+    struct timespec ts;
+    ts.tv_sec = (time_t)(milliseconds / 1000U);
+    ts.tv_nsec = (long)((milliseconds % 1000U) * 1000000UL);
+    nanosleep(&ts, NULL);
+}
+
+int lltd_port_send_frame(void *iface_ctx, const void *frame, size_t frame_len) {
+    (void)iface_ctx;
+    (void)frame;
+    (void)frame_len;
+    return -1;
+}
 
 static void lltd_vlog(FILE *out, const char *prefix, const char *fmt, va_list args) {
     if (!out) {

--- a/os/linux/lltd_port.c
+++ b/os/linux/lltd_port.c
@@ -6,6 +6,28 @@
 #include <string.h>
 #include <time.h>
 
+void *lltd_port_memcpy(void *destination, const void *source, size_t num) {
+    return memcpy(destination, source, num);
+}
+
+int lltd_port_memcmp(const void *lhs, const void *rhs, size_t num) {
+    return memcmp(lhs, rhs, num);
+}
+
+void lltd_port_sleep_ms(uint32_t milliseconds) {
+    struct timespec ts;
+    ts.tv_sec = (time_t)(milliseconds / 1000U);
+    ts.tv_nsec = (long)((milliseconds % 1000U) * 1000000UL);
+    nanosleep(&ts, NULL);
+}
+
+int lltd_port_send_frame(void *iface_ctx, const void *frame, size_t frame_len) {
+    (void)iface_ctx;
+    (void)frame;
+    (void)frame_len;
+    return -1;
+}
+
 static void lltd_vlog(FILE *out, const char *prefix, const char *fmt, va_list args) {
     if (!out) {
         out = stderr;

--- a/os/posix/lltd_port.c
+++ b/os/posix/lltd_port.c
@@ -6,6 +6,28 @@
 #include <string.h>
 #include <time.h>
 
+void *lltd_port_memcpy(void *destination, const void *source, size_t num) {
+    return memcpy(destination, source, num);
+}
+
+int lltd_port_memcmp(const void *lhs, const void *rhs, size_t num) {
+    return memcmp(lhs, rhs, num);
+}
+
+void lltd_port_sleep_ms(uint32_t milliseconds) {
+    struct timespec ts;
+    ts.tv_sec = (time_t)(milliseconds / 1000U);
+    ts.tv_nsec = (long)((milliseconds % 1000U) * 1000000UL);
+    nanosleep(&ts, NULL);
+}
+
+int lltd_port_send_frame(void *iface_ctx, const void *frame, size_t frame_len) {
+    (void)iface_ctx;
+    (void)frame;
+    (void)frame_len;
+    return -1;
+}
+
 static void lltd_vlog(FILE *out, const char *prefix, const char *fmt, va_list args) {
     if (!out) {
         out = stderr;

--- a/os/windows/win32-user/lltd_port.c
+++ b/os/windows/win32-user/lltd_port.c
@@ -6,6 +6,25 @@
 #include <string.h>
 #include <windows.h>
 
+void *lltd_port_memcpy(void *destination, const void *source, size_t num) {
+    return memcpy(destination, source, num);
+}
+
+int lltd_port_memcmp(const void *lhs, const void *rhs, size_t num) {
+    return memcmp(lhs, rhs, num);
+}
+
+void lltd_port_sleep_ms(uint32_t milliseconds) {
+    Sleep(milliseconds);
+}
+
+int lltd_port_send_frame(void *iface_ctx, const void *frame, size_t frame_len) {
+    (void)iface_ctx;
+    (void)frame;
+    (void)frame_len;
+    return -1;
+}
+
 static void lltd_vlog(FILE *out, const char *prefix, const char *fmt, va_list args) {
     if (!out) {
         out = stderr;


### PR DESCRIPTION
Implementeaza primitivele lipsa in `lltdResponder/lltdPort.h` si in port-urile existente.

Fixes #22.
